### PR TITLE
save db immediately after each toot

### DIFF
--- a/t2m
+++ b/t2m
@@ -125,9 +125,9 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
                     continue
 
                 print("[forwarding] >>", toot["text"].encode("Utf-8"), " ".join(toot["medias"]))
-                time.sleep(30)
-
                 db.setdefault(twitter_handle, {}).setdefault("done", []).append(toot["id"])
+                save_db(db)
+                time.sleep(30)
 
     if only_mark_as_seen:
         print("Mark all available tweets as seen")


### PR DESCRIPTION
so that if you ctrl-c and relaunch, you don't repeat a toot that was already sent