### PR TITLE
fix unicode decoding error when loading the retweet template

### DIFF
--- a/t2m
+++ b/t2m
@@ -69,7 +69,7 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
     to_toot = []
 
     if retweets:
-        with open("retweet.tmpl") as f:
+        with open("retweet.tmpl", encoding="utf-8") as f:
             retweet_template = f.read()
 
     # select tweets first

--- a/t2m
+++ b/t2m
@@ -8,6 +8,7 @@ import json
 import time
 import shutil
 import tempfile
+import codecs
 
 try:
     from urllib import urlretrieve
@@ -69,7 +70,7 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
     to_toot = []
 
     if retweets:
-        with open("retweet.tmpl", encoding="utf-8") as f:
+        with codecs.open("retweet.tmpl", encoding="utf-8") as f:
             retweet_template = f.read()
 
     # select tweets first


### PR DESCRIPTION
tried setting this up with retweets on python 3.4.5 and I was getting unicode decode errors when it tried to open the retweet template
trivial fix, just add encoding="utf-8" to open, should also be supported in 2.7