### PR TITLE
Properly handle quoted tweets

### DIFF
--- a/t2m
+++ b/t2m
@@ -75,16 +75,20 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
     # select tweets first
     for i in reversed(t.GetUserTimeline(screen_name=twitter_handle, count=200)):
 
-        if i.retweeted_status:
+        retweeted_status = i.retweeted_status
+        if not retweeted_status:
+            retweeted_status = i.quoted_status
+
+        if retweeted_status:
             if retweets:
                 text = retweet_template % {
-                    "text": i.retweeted_status.full_text,
-                    "user": i.retweeted_status.user.screen_name,
-                    "id": i.retweeted_status.id
+                    "text": retweeted_status.full_text,
+                    "user": retweeted_status.user.screen_name,
+                    "id": retweeted_status.id
                 }
 
-                urls = i.retweeted_status.urls
-                media = i.retweeted_status.media
+                urls = retweeted_status.urls
+                media = retweeted_status.media
             else:
                 continue
         else:

--- a/t2m
+++ b/t2m
@@ -87,6 +87,9 @@ def forward(db, twitter_handle, mastodon_handle, debug, number=None, only_mark_a
                     "id": retweeted_status.id
                 }
 
+                if i.quoted_status:
+                    text = i.full_text + "\n\n" + text
+
                 urls = retweeted_status.urls
                 media = retweeted_status.media
             else:


### PR DESCRIPTION
Currently, quoted tweets are tooted without any media and without the original tweet's text.

This addresses both issues